### PR TITLE
Indirect-macro

### DIFF
--- a/c64-assembler-6502/examples/codegen_instruction_test.rs
+++ b/c64-assembler-6502/examples/codegen_instruction_test.rs
@@ -1,8 +1,8 @@
 use c64_assembler_6502::{
     isa_6502,
     opcodes::{
-        NO_ABSOLUTE, NO_ABSOLUTE_X, NO_ABSOLUTE_Y, NO_ACCUMULATOR, NO_IMMEDIATE, NO_IMPLIED, NO_RELATIVE, NO_ZEROPAGE,
-        NO_ZEROPAGE_X, NO_ZEROPAGE_Y,
+        NO_ABSOLUTE, NO_ABSOLUTE_X, NO_ABSOLUTE_Y, NO_ACCUMULATOR, NO_IMMEDIATE, NO_IMPLIED, NO_INDIRECT, NO_RELATIVE,
+        NO_ZEROPAGE, NO_ZEROPAGE_X, NO_ZEROPAGE_Y,
     },
 };
 
@@ -173,8 +173,7 @@ fn main() {
                 def.instruction
             ));
         }
-        /*
-        if def.indirect != UNUSED {
+        if def.indirect != NO_INDIRECT {
             lines.push(format!(
                 "
                 #[test]
@@ -183,12 +182,13 @@ fn main() {
                         instructions!({0} (test)),
                         OP,
                         AddressMode::Indirect(AddressReference::new(&\"test\")),
-                    );
-                }}
-                ",
+                        );
+                        }}
+                        ",
                 def.instruction.to_string()
             ));
         }
+        /*
         if def.indexed_indirect != UNUSED {
             lines.push(format!(
                 "

--- a/c64-assembler-6502/examples/codegen_instruction_test.rs
+++ b/c64-assembler-6502/examples/codegen_instruction_test.rs
@@ -61,7 +61,7 @@ fn main() {
                     test_first(
                         instructions!({0} #<test),
                         OP,
-                        AddressMode::Immediate(Immediate::Low(AddressReference::new(&\"test\"))),
+                        AddressMode::Immediate(Immediate::Low(AddressReference::new(\"test\"))),
                     );
                 }}
 
@@ -70,7 +70,7 @@ fn main() {
                     test_first(
                         instructions!({0} #>test),
                         OP,
-                        AddressMode::Immediate(Immediate::High(AddressReference::new(&\"test\"))),
+                        AddressMode::Immediate(Immediate::High(AddressReference::new(\"test\"))),
                     );
                 }}
                 ",
@@ -102,7 +102,7 @@ fn main() {
                     test_first(
                         instructions!({0} test),
                         OP,
-                        AddressMode::Absolute(AddressReference::new(&\"test\")),
+                        AddressMode::Absolute(AddressReference::new(\"test\")),
                     );
                 }}
 
@@ -111,7 +111,7 @@ fn main() {
                     test_first(
                         instructions!({0} test+1),
                         OP,
-                        AddressMode::Absolute(AddressReference::with_offset(&\"test\", 1)),
+                        AddressMode::Absolute(AddressReference::with_offset(\"test\", 1)),
                     );
                 }}
                 ",
@@ -126,7 +126,7 @@ fn main() {
                     test_first(
                         instructions!({0} test),
                         OP,
-                        AddressMode::Relative(AddressReference::new(&\"test\")),
+                        AddressMode::Relative(AddressReference::new(\"test\")),
                     );
                 }}
 
@@ -135,7 +135,7 @@ fn main() {
                     test_first(
                         instructions!({0} test+1),
                         OP,
-                        AddressMode::Relative(AddressReference::with_offset(&\"test\", 1)),
+                        AddressMode::Relative(AddressReference::with_offset(\"test\", 1)),
                     );
                 }}
                 ",
@@ -151,7 +151,7 @@ fn main() {
                     test_first(
                         instructions!({0} test,x),
                         OP,
-                        AddressMode::AbsoluteX(AddressReference::new(&\"test\")),
+                        AddressMode::AbsoluteX(AddressReference::new(\"test\")),
                     );
                 }}
                 ",
@@ -166,7 +166,7 @@ fn main() {
                     test_first(
                         instructions!({0} test,y),
                         OP,
-                        AddressMode::AbsoluteY(AddressReference::new(&\"test\")),
+                        AddressMode::AbsoluteY(AddressReference::new(\"test\")),
                     );
                 }}
                 ",
@@ -182,7 +182,7 @@ fn main() {
                     test_first(
                         instructions!({0} (test)),
                         OP,
-                        AddressMode::Indirect(AddressReference::new(&\"test\")),
+                        AddressMode::Indirect(AddressReference::new(\"test\")),
                         );
                         }}
                         ",
@@ -198,7 +198,7 @@ fn main() {
                     test_first(
                         instructions!({0} (test,x)),
                         OP,
-                        AddressMode::IndexedIndirect(AddressReference::new(&\"test\")),
+                        AddressMode::IndexedIndirect(AddressReference::new(\"test\")),
                     );
                 }}
                 ",
@@ -214,7 +214,7 @@ fn main() {
                     test_first(
                         instructions!({0} (test),y),
                         OP,
-                        AddressMode::IndirectIndexed(AddressReference::new(&\"test\")),
+                        AddressMode::IndirectIndexed(AddressReference::new(\"test\")),
                     );
                 }}
                 ",

--- a/c64-assembler-6502/examples/codegen_instruction_test.rs
+++ b/c64-assembler-6502/examples/codegen_instruction_test.rs
@@ -189,8 +189,7 @@ fn main() {
                 def.instruction.to_string()
             ));
         }
-        /*
-        if def.indexed_indirect != UNUSED {
+        if def.indexed_indirect != NO_INDIRECT {
             lines.push(format!(
                 "
                 #[test]
@@ -205,8 +204,7 @@ fn main() {
                 def.instruction.to_string()
             ));
         }
-
-        if def.indirect_indexed != UNUSED {
+        if def.indirect_indexed != NO_INDIRECT {
             lines.push(format!(
                 "
                 #[test]
@@ -221,7 +219,6 @@ fn main() {
                 def.instruction.to_string()
             ));
         }
-        */
 
         // Close module
         lines.push(

--- a/c64-assembler-6502/examples/codegen_instruction_test.rs
+++ b/c64-assembler-6502/examples/codegen_instruction_test.rs
@@ -173,6 +173,7 @@ fn main() {
                 def.instruction
             ));
         }
+
         if def.indirect != NO_INDIRECT {
             lines.push(format!(
                 "

--- a/c64-assembler-macro/src/lib.rs
+++ b/c64-assembler-macro/src/lib.rs
@@ -224,6 +224,7 @@ fn build_address_mode_indirect(line: &mut Vec<String>, tokens: &[TokenTree]) -> 
             if let TokenTree::Punct(punct) = &token {
                 if punct.as_char() == ',' {
                     is_indexed_indirect = true;
+                    break;
                 }
             }
         }
@@ -235,10 +236,10 @@ fn build_address_mode_indirect(line: &mut Vec<String>, tokens: &[TokenTree]) -> 
     }
 
     if is_indexed_indirect {
-        line.push(format!("_ind_y(\"{address}\")"));
+        line.push(format!("_ind_x(\"{address}\")"));
         1
     } else if is_indirect_indexed {
-        line.push(format!("_ind_x(\"{address}\")"));
+        line.push(format!("_ind_y(\"{address}\")"));
         3
     } else {
         line.push(format!("_ind(\"{address}\")"));

--- a/c64-assembler-macro/src/lib.rs
+++ b/c64-assembler-macro/src/lib.rs
@@ -387,12 +387,12 @@ pub fn function(input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn instructions(input: TokenStream) -> TokenStream {
-    dbg!(input.clone());
+    //dbg!(input.clone());
     let mut lines = Vec::<String>::default();
     lines.push("{".to_string());
     lines.push("  use c64_assembler::builder::{*};".to_string());
     lines.push(build_instructions(input));
     lines.push("}".to_string());
-    println!("{:#?}", lines.join("\n"));
+    //println!("{:#?}", lines.join("\n"));
     lines.join("\n").parse().unwrap()
 }

--- a/c64-assembler-macro/src/lib.rs
+++ b/c64-assembler-macro/src/lib.rs
@@ -119,7 +119,22 @@ fn build_function(input: TokenStream) -> String {
     lines.push("    .build()".to_string());
     lines.join("\n")
 }
-
+/*
+Ident {
+    ident: "jmp",
+    span: #0 bytes(20193..20196),
+},
+Group {
+    delimiter: Parenthesis,
+    stream: TokenStream [
+        Ident {
+            ident: "test",
+            span: #0 bytes(20198..20202),
+        },
+        ],
+        span: #0 bytes(20197..20203),
+    },
+`*/
 fn build_address_mode(
     line: &mut Vec<String>,
     tokens: &[TokenTree],
@@ -147,7 +162,7 @@ fn build_address_mode(
             assert!(allow_absolute);
             return build_address_mode_absolute(line, tokens);
         }
-        _ => todo!(),
+        _ => todo!("HUH!"),
     }
     0
 }
@@ -341,12 +356,12 @@ pub fn function(input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn instructions(input: TokenStream) -> TokenStream {
-    //dbg!(input.clone());
+    dbg!(input.clone());
     let mut lines = Vec::<String>::default();
     lines.push("{".to_string());
     lines.push("  use c64_assembler::builder::{*};".to_string());
     lines.push(build_instructions(input));
     lines.push("}".to_string());
-    //println!("{:#?}", lines.join("\n"));
+    println!("{:#?}", lines.join("\n"));
     lines.join("\n").parse().unwrap()
 }

--- a/c64-assembler/tests/macro_instructions.rs
+++ b/c64-assembler/tests/macro_instructions.rs
@@ -89,6 +89,24 @@ mod adc {
             AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
+
+    #[test]
+    fn ind_x() {
+        test_first(
+            instructions!(adc(test, x)),
+            OP,
+            AddressMode::IndexedIndirect(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_y() {
+        test_first(
+            instructions!(adc(test), y),
+            OP,
+            AddressMode::IndirectIndexed(AddressReference::new("test")),
+        );
+    }
 }
 
 mod and {
@@ -162,6 +180,24 @@ mod and {
             instructions!(and test,y),
             OP,
             AddressMode::AbsoluteY(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_x() {
+        test_first(
+            instructions!(and(test, x)),
+            OP,
+            AddressMode::IndexedIndirect(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_y() {
+        test_first(
+            instructions!(and(test), y),
+            OP,
+            AddressMode::IndirectIndexed(AddressReference::new("test")),
         );
     }
 }
@@ -568,6 +604,24 @@ mod cmp {
             AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
+
+    #[test]
+    fn ind_x() {
+        test_first(
+            instructions!(cmp(test, x)),
+            OP,
+            AddressMode::IndexedIndirect(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_y() {
+        test_first(
+            instructions!(cmp(test), y),
+            OP,
+            AddressMode::IndirectIndexed(AddressReference::new("test")),
+        );
+    }
 }
 
 mod cpx {
@@ -805,6 +859,24 @@ mod eor {
             AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
+
+    #[test]
+    fn ind_x() {
+        test_first(
+            instructions!(eor(test, x)),
+            OP,
+            AddressMode::IndexedIndirect(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_y() {
+        test_first(
+            instructions!(eor(test), y),
+            OP,
+            AddressMode::IndirectIndexed(AddressReference::new("test")),
+        );
+    }
 }
 
 mod inc {
@@ -882,6 +954,7 @@ mod jmp {
             AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
+
     #[test]
     fn ind() {
         test_first(
@@ -992,6 +1065,24 @@ mod lda {
             instructions!(lda test,y),
             OP,
             AddressMode::AbsoluteY(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_x() {
+        test_first(
+            instructions!(lda(test, x)),
+            OP,
+            AddressMode::IndexedIndirect(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_y() {
+        test_first(
+            instructions!(lda(test), y),
+            OP,
+            AddressMode::IndirectIndexed(AddressReference::new("test")),
         );
     }
 }
@@ -1249,6 +1340,24 @@ mod ora {
             AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
+
+    #[test]
+    fn ind_x() {
+        test_first(
+            instructions!(ora(test, x)),
+            OP,
+            AddressMode::IndexedIndirect(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_y() {
+        test_first(
+            instructions!(ora(test), y),
+            OP,
+            AddressMode::IndirectIndexed(AddressReference::new("test")),
+        );
+    }
 }
 
 #[test]
@@ -1440,6 +1549,24 @@ mod sbc {
             AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
+
+    #[test]
+    fn ind_x() {
+        test_first(
+            instructions!(sbc(test, x)),
+            OP,
+            AddressMode::IndexedIndirect(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_y() {
+        test_first(
+            instructions!(sbc(test), y),
+            OP,
+            AddressMode::IndirectIndexed(AddressReference::new("test")),
+        );
+    }
 }
 
 #[test]
@@ -1500,6 +1627,24 @@ mod sta {
             instructions!(sta test,y),
             OP,
             AddressMode::AbsoluteY(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_x() {
+        test_first(
+            instructions!(sta(test, x)),
+            OP,
+            AddressMode::IndexedIndirect(AddressReference::new("test")),
+        );
+    }
+
+    #[test]
+    fn ind_y() {
+        test_first(
+            instructions!(sta(test), y),
+            OP,
+            AddressMode::IndirectIndexed(AddressReference::new("test")),
         );
     }
 }

--- a/c64-assembler/tests/macro_instructions.rs
+++ b/c64-assembler/tests/macro_instructions.rs
@@ -41,7 +41,7 @@ mod adc {
         test_first(
             instructions!(adc #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -50,7 +50,7 @@ mod adc {
         test_first(
             instructions!(adc #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -59,7 +59,7 @@ mod adc {
         test_first(
             instructions!(adc test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -68,7 +68,7 @@ mod adc {
         test_first(
             instructions!(adc test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -77,7 +77,7 @@ mod adc {
         test_first(
             instructions!(adc test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 
@@ -86,7 +86,7 @@ mod adc {
         test_first(
             instructions!(adc test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -116,7 +116,7 @@ mod and {
         test_first(
             instructions!(and #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -125,7 +125,7 @@ mod and {
         test_first(
             instructions!(and #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -134,7 +134,7 @@ mod and {
         test_first(
             instructions!(and test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -143,7 +143,7 @@ mod and {
         test_first(
             instructions!(and test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -152,7 +152,7 @@ mod and {
         test_first(
             instructions!(and test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 
@@ -161,7 +161,7 @@ mod and {
         test_first(
             instructions!(and test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -186,7 +186,7 @@ mod asl {
         test_first(
             instructions!(asl test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -195,7 +195,7 @@ mod asl {
         test_first(
             instructions!(asl test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -204,7 +204,7 @@ mod asl {
         test_first(
             instructions!(asl test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 }
@@ -224,7 +224,7 @@ mod bcc {
         test_first(
             instructions!(bcc test),
             OP,
-            AddressMode::Relative(AddressReference::new(&"test")),
+            AddressMode::Relative(AddressReference::new("test")),
         );
     }
 
@@ -233,7 +233,7 @@ mod bcc {
         test_first(
             instructions!(bcc test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Relative(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -253,7 +253,7 @@ mod bcs {
         test_first(
             instructions!(bcs test),
             OP,
-            AddressMode::Relative(AddressReference::new(&"test")),
+            AddressMode::Relative(AddressReference::new("test")),
         );
     }
 
@@ -262,7 +262,7 @@ mod bcs {
         test_first(
             instructions!(bcs test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Relative(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -282,7 +282,7 @@ mod beq {
         test_first(
             instructions!(beq test),
             OP,
-            AddressMode::Relative(AddressReference::new(&"test")),
+            AddressMode::Relative(AddressReference::new("test")),
         );
     }
 
@@ -291,7 +291,7 @@ mod beq {
         test_first(
             instructions!(beq test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Relative(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -311,7 +311,7 @@ mod bit {
         test_first(
             instructions!(bit test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -320,7 +320,7 @@ mod bit {
         test_first(
             instructions!(bit test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -340,7 +340,7 @@ mod bmi {
         test_first(
             instructions!(bmi test),
             OP,
-            AddressMode::Relative(AddressReference::new(&"test")),
+            AddressMode::Relative(AddressReference::new("test")),
         );
     }
 
@@ -349,7 +349,7 @@ mod bmi {
         test_first(
             instructions!(bmi test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Relative(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -369,7 +369,7 @@ mod bne {
         test_first(
             instructions!(bne test),
             OP,
-            AddressMode::Relative(AddressReference::new(&"test")),
+            AddressMode::Relative(AddressReference::new("test")),
         );
     }
 
@@ -378,7 +378,7 @@ mod bne {
         test_first(
             instructions!(bne test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Relative(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -398,7 +398,7 @@ mod bpl {
         test_first(
             instructions!(bpl test),
             OP,
-            AddressMode::Relative(AddressReference::new(&"test")),
+            AddressMode::Relative(AddressReference::new("test")),
         );
     }
 
@@ -407,7 +407,7 @@ mod bpl {
         test_first(
             instructions!(bpl test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Relative(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -432,7 +432,7 @@ mod bvc {
         test_first(
             instructions!(bvc test),
             OP,
-            AddressMode::Relative(AddressReference::new(&"test")),
+            AddressMode::Relative(AddressReference::new("test")),
         );
     }
 
@@ -441,7 +441,7 @@ mod bvc {
         test_first(
             instructions!(bvc test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Relative(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -461,7 +461,7 @@ mod bvs {
         test_first(
             instructions!(bvs test),
             OP,
-            AddressMode::Relative(AddressReference::new(&"test")),
+            AddressMode::Relative(AddressReference::new("test")),
         );
     }
 
@@ -470,7 +470,7 @@ mod bvs {
         test_first(
             instructions!(bvs test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Relative(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -520,7 +520,7 @@ mod cmp {
         test_first(
             instructions!(cmp #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -529,7 +529,7 @@ mod cmp {
         test_first(
             instructions!(cmp #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -538,7 +538,7 @@ mod cmp {
         test_first(
             instructions!(cmp test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -547,7 +547,7 @@ mod cmp {
         test_first(
             instructions!(cmp test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -556,7 +556,7 @@ mod cmp {
         test_first(
             instructions!(cmp test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 
@@ -565,7 +565,7 @@ mod cmp {
         test_first(
             instructions!(cmp test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -595,7 +595,7 @@ mod cpx {
         test_first(
             instructions!(cpx #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -604,7 +604,7 @@ mod cpx {
         test_first(
             instructions!(cpx #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -613,7 +613,7 @@ mod cpx {
         test_first(
             instructions!(cpx test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -622,7 +622,7 @@ mod cpx {
         test_first(
             instructions!(cpx test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -652,7 +652,7 @@ mod cpy {
         test_first(
             instructions!(cpy #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -661,7 +661,7 @@ mod cpy {
         test_first(
             instructions!(cpy #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -670,7 +670,7 @@ mod cpy {
         test_first(
             instructions!(cpy test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -679,7 +679,7 @@ mod cpy {
         test_first(
             instructions!(cpy test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -699,7 +699,7 @@ mod dec {
         test_first(
             instructions!(dec test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -708,7 +708,7 @@ mod dec {
         test_first(
             instructions!(dec test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -717,7 +717,7 @@ mod dec {
         test_first(
             instructions!(dec test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 }
@@ -757,7 +757,7 @@ mod eor {
         test_first(
             instructions!(eor #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -766,7 +766,7 @@ mod eor {
         test_first(
             instructions!(eor #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -775,7 +775,7 @@ mod eor {
         test_first(
             instructions!(eor test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -784,7 +784,7 @@ mod eor {
         test_first(
             instructions!(eor test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -793,7 +793,7 @@ mod eor {
         test_first(
             instructions!(eor test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 
@@ -802,7 +802,7 @@ mod eor {
         test_first(
             instructions!(eor test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -822,7 +822,7 @@ mod inc {
         test_first(
             instructions!(inc test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -831,7 +831,7 @@ mod inc {
         test_first(
             instructions!(inc test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -840,7 +840,7 @@ mod inc {
         test_first(
             instructions!(inc test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 }
@@ -870,7 +870,7 @@ mod jmp {
         test_first(
             instructions!(jmp test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -879,16 +879,15 @@ mod jmp {
         test_first(
             instructions!(jmp test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
-
     #[test]
     fn ind() {
         test_first(
-            instructions!(jmp (test)),
+            instructions!(jmp(test)),
             OP,
-            AddressMode::Indirect(AddressReference::new(&"test")),
+            AddressMode::Indirect(AddressReference::new("test")),
         );
     }
 }
@@ -908,7 +907,7 @@ mod jsr {
         test_first(
             instructions!(jsr test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -917,7 +916,7 @@ mod jsr {
         test_first(
             instructions!(jsr test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 }
@@ -947,7 +946,7 @@ mod lda {
         test_first(
             instructions!(lda #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -956,7 +955,7 @@ mod lda {
         test_first(
             instructions!(lda #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -965,7 +964,7 @@ mod lda {
         test_first(
             instructions!(lda test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -974,7 +973,7 @@ mod lda {
         test_first(
             instructions!(lda test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -983,7 +982,7 @@ mod lda {
         test_first(
             instructions!(lda test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 
@@ -992,7 +991,7 @@ mod lda {
         test_first(
             instructions!(lda test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -1022,7 +1021,7 @@ mod ldx {
         test_first(
             instructions!(ldx #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -1031,7 +1030,7 @@ mod ldx {
         test_first(
             instructions!(ldx #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -1040,7 +1039,7 @@ mod ldx {
         test_first(
             instructions!(ldx test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1049,7 +1048,7 @@ mod ldx {
         test_first(
             instructions!(ldx test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1058,7 +1057,7 @@ mod ldx {
         test_first(
             instructions!(ldx test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -1088,7 +1087,7 @@ mod ldy {
         test_first(
             instructions!(ldy #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -1097,7 +1096,7 @@ mod ldy {
         test_first(
             instructions!(ldy #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -1106,7 +1105,7 @@ mod ldy {
         test_first(
             instructions!(ldy test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1115,7 +1114,7 @@ mod ldy {
         test_first(
             instructions!(ldy test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1124,7 +1123,7 @@ mod ldy {
         test_first(
             instructions!(ldy test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 }
@@ -1149,7 +1148,7 @@ mod lsr {
         test_first(
             instructions!(lsr test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1158,7 +1157,7 @@ mod lsr {
         test_first(
             instructions!(lsr test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1167,7 +1166,7 @@ mod lsr {
         test_first(
             instructions!(lsr test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 }
@@ -1202,7 +1201,7 @@ mod ora {
         test_first(
             instructions!(ora #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -1211,7 +1210,7 @@ mod ora {
         test_first(
             instructions!(ora #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -1220,7 +1219,7 @@ mod ora {
         test_first(
             instructions!(ora test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1229,7 +1228,7 @@ mod ora {
         test_first(
             instructions!(ora test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1238,7 +1237,7 @@ mod ora {
         test_first(
             instructions!(ora test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 
@@ -1247,7 +1246,7 @@ mod ora {
         test_first(
             instructions!(ora test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -1292,7 +1291,7 @@ mod rol {
         test_first(
             instructions!(rol test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1301,7 +1300,7 @@ mod rol {
         test_first(
             instructions!(rol test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1310,7 +1309,7 @@ mod rol {
         test_first(
             instructions!(rol test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 }
@@ -1335,7 +1334,7 @@ mod ror {
         test_first(
             instructions!(ror test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1344,7 +1343,7 @@ mod ror {
         test_first(
             instructions!(ror test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1353,7 +1352,7 @@ mod ror {
         test_first(
             instructions!(ror test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 }
@@ -1393,7 +1392,7 @@ mod sbc {
         test_first(
             instructions!(sbc #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
         );
     }
 
@@ -1402,7 +1401,7 @@ mod sbc {
         test_first(
             instructions!(sbc #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
         );
     }
 
@@ -1411,7 +1410,7 @@ mod sbc {
         test_first(
             instructions!(sbc test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1420,7 +1419,7 @@ mod sbc {
         test_first(
             instructions!(sbc test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1429,7 +1428,7 @@ mod sbc {
         test_first(
             instructions!(sbc test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 
@@ -1438,7 +1437,7 @@ mod sbc {
         test_first(
             instructions!(sbc test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -1473,7 +1472,7 @@ mod sta {
         test_first(
             instructions!(sta test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1482,7 +1481,7 @@ mod sta {
         test_first(
             instructions!(sta test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1491,7 +1490,7 @@ mod sta {
         test_first(
             instructions!(sta test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 
@@ -1500,7 +1499,7 @@ mod sta {
         test_first(
             instructions!(sta test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -1520,7 +1519,7 @@ mod stx {
         test_first(
             instructions!(stx test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1529,7 +1528,7 @@ mod stx {
         test_first(
             instructions!(stx test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1538,7 +1537,7 @@ mod stx {
         test_first(
             instructions!(stx test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new(&"test")),
+            AddressMode::AbsoluteY(AddressReference::new("test")),
         );
     }
 }
@@ -1558,7 +1557,7 @@ mod sty {
         test_first(
             instructions!(sty test),
             OP,
-            AddressMode::Absolute(AddressReference::new(&"test")),
+            AddressMode::Absolute(AddressReference::new("test")),
         );
     }
 
@@ -1567,7 +1566,7 @@ mod sty {
         test_first(
             instructions!(sty test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
         );
     }
 
@@ -1576,7 +1575,7 @@ mod sty {
         test_first(
             instructions!(sty test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new(&"test")),
+            AddressMode::AbsoluteX(AddressReference::new("test")),
         );
     }
 }

--- a/c64-assembler/tests/macro_instructions.rs
+++ b/c64-assembler/tests/macro_instructions.rs
@@ -41,7 +41,7 @@ mod adc {
         test_first(
             instructions!(adc #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -50,7 +50,7 @@ mod adc {
         test_first(
             instructions!(adc #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -59,7 +59,7 @@ mod adc {
         test_first(
             instructions!(adc test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -68,7 +68,7 @@ mod adc {
         test_first(
             instructions!(adc test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -77,7 +77,7 @@ mod adc {
         test_first(
             instructions!(adc test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 
@@ -86,7 +86,7 @@ mod adc {
         test_first(
             instructions!(adc test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -116,7 +116,7 @@ mod and {
         test_first(
             instructions!(and #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -125,7 +125,7 @@ mod and {
         test_first(
             instructions!(and #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -134,7 +134,7 @@ mod and {
         test_first(
             instructions!(and test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -143,7 +143,7 @@ mod and {
         test_first(
             instructions!(and test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -152,7 +152,7 @@ mod and {
         test_first(
             instructions!(and test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 
@@ -161,7 +161,7 @@ mod and {
         test_first(
             instructions!(and test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -186,7 +186,7 @@ mod asl {
         test_first(
             instructions!(asl test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -195,7 +195,7 @@ mod asl {
         test_first(
             instructions!(asl test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -204,7 +204,7 @@ mod asl {
         test_first(
             instructions!(asl test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 }
@@ -224,7 +224,7 @@ mod bcc {
         test_first(
             instructions!(bcc test),
             OP,
-            AddressMode::Relative(AddressReference::new("test")),
+            AddressMode::Relative(AddressReference::new(&"test")),
         );
     }
 
@@ -233,7 +233,7 @@ mod bcc {
         test_first(
             instructions!(bcc test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset("test", 1)),
+            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -253,7 +253,7 @@ mod bcs {
         test_first(
             instructions!(bcs test),
             OP,
-            AddressMode::Relative(AddressReference::new("test")),
+            AddressMode::Relative(AddressReference::new(&"test")),
         );
     }
 
@@ -262,7 +262,7 @@ mod bcs {
         test_first(
             instructions!(bcs test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset("test", 1)),
+            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -282,7 +282,7 @@ mod beq {
         test_first(
             instructions!(beq test),
             OP,
-            AddressMode::Relative(AddressReference::new("test")),
+            AddressMode::Relative(AddressReference::new(&"test")),
         );
     }
 
@@ -291,7 +291,7 @@ mod beq {
         test_first(
             instructions!(beq test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset("test", 1)),
+            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -311,7 +311,7 @@ mod bit {
         test_first(
             instructions!(bit test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -320,7 +320,7 @@ mod bit {
         test_first(
             instructions!(bit test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -340,7 +340,7 @@ mod bmi {
         test_first(
             instructions!(bmi test),
             OP,
-            AddressMode::Relative(AddressReference::new("test")),
+            AddressMode::Relative(AddressReference::new(&"test")),
         );
     }
 
@@ -349,7 +349,7 @@ mod bmi {
         test_first(
             instructions!(bmi test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset("test", 1)),
+            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -369,7 +369,7 @@ mod bne {
         test_first(
             instructions!(bne test),
             OP,
-            AddressMode::Relative(AddressReference::new("test")),
+            AddressMode::Relative(AddressReference::new(&"test")),
         );
     }
 
@@ -378,7 +378,7 @@ mod bne {
         test_first(
             instructions!(bne test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset("test", 1)),
+            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -398,7 +398,7 @@ mod bpl {
         test_first(
             instructions!(bpl test),
             OP,
-            AddressMode::Relative(AddressReference::new("test")),
+            AddressMode::Relative(AddressReference::new(&"test")),
         );
     }
 
@@ -407,7 +407,7 @@ mod bpl {
         test_first(
             instructions!(bpl test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset("test", 1)),
+            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -432,7 +432,7 @@ mod bvc {
         test_first(
             instructions!(bvc test),
             OP,
-            AddressMode::Relative(AddressReference::new("test")),
+            AddressMode::Relative(AddressReference::new(&"test")),
         );
     }
 
@@ -441,7 +441,7 @@ mod bvc {
         test_first(
             instructions!(bvc test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset("test", 1)),
+            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -461,7 +461,7 @@ mod bvs {
         test_first(
             instructions!(bvs test),
             OP,
-            AddressMode::Relative(AddressReference::new("test")),
+            AddressMode::Relative(AddressReference::new(&"test")),
         );
     }
 
@@ -470,7 +470,7 @@ mod bvs {
         test_first(
             instructions!(bvs test+1),
             OP,
-            AddressMode::Relative(AddressReference::with_offset("test", 1)),
+            AddressMode::Relative(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -520,7 +520,7 @@ mod cmp {
         test_first(
             instructions!(cmp #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -529,7 +529,7 @@ mod cmp {
         test_first(
             instructions!(cmp #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -538,7 +538,7 @@ mod cmp {
         test_first(
             instructions!(cmp test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -547,7 +547,7 @@ mod cmp {
         test_first(
             instructions!(cmp test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -556,7 +556,7 @@ mod cmp {
         test_first(
             instructions!(cmp test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 
@@ -565,7 +565,7 @@ mod cmp {
         test_first(
             instructions!(cmp test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -595,7 +595,7 @@ mod cpx {
         test_first(
             instructions!(cpx #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -604,7 +604,7 @@ mod cpx {
         test_first(
             instructions!(cpx #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -613,7 +613,7 @@ mod cpx {
         test_first(
             instructions!(cpx test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -622,7 +622,7 @@ mod cpx {
         test_first(
             instructions!(cpx test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -652,7 +652,7 @@ mod cpy {
         test_first(
             instructions!(cpy #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -661,7 +661,7 @@ mod cpy {
         test_first(
             instructions!(cpy #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -670,7 +670,7 @@ mod cpy {
         test_first(
             instructions!(cpy test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -679,7 +679,7 @@ mod cpy {
         test_first(
             instructions!(cpy test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -699,7 +699,7 @@ mod dec {
         test_first(
             instructions!(dec test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -708,7 +708,7 @@ mod dec {
         test_first(
             instructions!(dec test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -717,7 +717,7 @@ mod dec {
         test_first(
             instructions!(dec test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 }
@@ -757,7 +757,7 @@ mod eor {
         test_first(
             instructions!(eor #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -766,7 +766,7 @@ mod eor {
         test_first(
             instructions!(eor #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -775,7 +775,7 @@ mod eor {
         test_first(
             instructions!(eor test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -784,7 +784,7 @@ mod eor {
         test_first(
             instructions!(eor test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -793,7 +793,7 @@ mod eor {
         test_first(
             instructions!(eor test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 
@@ -802,7 +802,7 @@ mod eor {
         test_first(
             instructions!(eor test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -822,7 +822,7 @@ mod inc {
         test_first(
             instructions!(inc test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -831,7 +831,7 @@ mod inc {
         test_first(
             instructions!(inc test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -840,7 +840,7 @@ mod inc {
         test_first(
             instructions!(inc test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 }
@@ -870,7 +870,7 @@ mod jmp {
         test_first(
             instructions!(jmp test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -879,7 +879,16 @@ mod jmp {
         test_first(
             instructions!(jmp test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
+        );
+    }
+
+    #[test]
+    fn ind() {
+        test_first(
+            instructions!(jmp (test)),
+            OP,
+            AddressMode::Indirect(AddressReference::new(&"test")),
         );
     }
 }
@@ -899,7 +908,7 @@ mod jsr {
         test_first(
             instructions!(jsr test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -908,7 +917,7 @@ mod jsr {
         test_first(
             instructions!(jsr test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 }
@@ -938,7 +947,7 @@ mod lda {
         test_first(
             instructions!(lda #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -947,7 +956,7 @@ mod lda {
         test_first(
             instructions!(lda #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -956,7 +965,7 @@ mod lda {
         test_first(
             instructions!(lda test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -965,7 +974,7 @@ mod lda {
         test_first(
             instructions!(lda test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -974,7 +983,7 @@ mod lda {
         test_first(
             instructions!(lda test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 
@@ -983,7 +992,7 @@ mod lda {
         test_first(
             instructions!(lda test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -1013,7 +1022,7 @@ mod ldx {
         test_first(
             instructions!(ldx #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -1022,7 +1031,7 @@ mod ldx {
         test_first(
             instructions!(ldx #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -1031,7 +1040,7 @@ mod ldx {
         test_first(
             instructions!(ldx test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1040,7 +1049,7 @@ mod ldx {
         test_first(
             instructions!(ldx test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1049,7 +1058,7 @@ mod ldx {
         test_first(
             instructions!(ldx test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -1079,7 +1088,7 @@ mod ldy {
         test_first(
             instructions!(ldy #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -1088,7 +1097,7 @@ mod ldy {
         test_first(
             instructions!(ldy #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -1097,7 +1106,7 @@ mod ldy {
         test_first(
             instructions!(ldy test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1106,7 +1115,7 @@ mod ldy {
         test_first(
             instructions!(ldy test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1115,7 +1124,7 @@ mod ldy {
         test_first(
             instructions!(ldy test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 }
@@ -1140,7 +1149,7 @@ mod lsr {
         test_first(
             instructions!(lsr test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1149,7 +1158,7 @@ mod lsr {
         test_first(
             instructions!(lsr test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1158,7 +1167,7 @@ mod lsr {
         test_first(
             instructions!(lsr test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 }
@@ -1193,7 +1202,7 @@ mod ora {
         test_first(
             instructions!(ora #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -1202,7 +1211,7 @@ mod ora {
         test_first(
             instructions!(ora #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -1211,7 +1220,7 @@ mod ora {
         test_first(
             instructions!(ora test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1220,7 +1229,7 @@ mod ora {
         test_first(
             instructions!(ora test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1229,7 +1238,7 @@ mod ora {
         test_first(
             instructions!(ora test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 
@@ -1238,7 +1247,7 @@ mod ora {
         test_first(
             instructions!(ora test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -1283,7 +1292,7 @@ mod rol {
         test_first(
             instructions!(rol test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1292,7 +1301,7 @@ mod rol {
         test_first(
             instructions!(rol test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1301,7 +1310,7 @@ mod rol {
         test_first(
             instructions!(rol test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 }
@@ -1326,7 +1335,7 @@ mod ror {
         test_first(
             instructions!(ror test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1335,7 +1344,7 @@ mod ror {
         test_first(
             instructions!(ror test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1344,7 +1353,7 @@ mod ror {
         test_first(
             instructions!(ror test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 }
@@ -1384,7 +1393,7 @@ mod sbc {
         test_first(
             instructions!(sbc #<test),
             OP,
-            AddressMode::Immediate(Immediate::Low(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::Low(AddressReference::new(&"test"))),
         );
     }
 
@@ -1393,7 +1402,7 @@ mod sbc {
         test_first(
             instructions!(sbc #>test),
             OP,
-            AddressMode::Immediate(Immediate::High(AddressReference::new("test"))),
+            AddressMode::Immediate(Immediate::High(AddressReference::new(&"test"))),
         );
     }
 
@@ -1402,7 +1411,7 @@ mod sbc {
         test_first(
             instructions!(sbc test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1411,7 +1420,7 @@ mod sbc {
         test_first(
             instructions!(sbc test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1420,7 +1429,7 @@ mod sbc {
         test_first(
             instructions!(sbc test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 
@@ -1429,7 +1438,7 @@ mod sbc {
         test_first(
             instructions!(sbc test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -1464,7 +1473,7 @@ mod sta {
         test_first(
             instructions!(sta test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1473,7 +1482,7 @@ mod sta {
         test_first(
             instructions!(sta test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1482,7 +1491,7 @@ mod sta {
         test_first(
             instructions!(sta test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 
@@ -1491,7 +1500,7 @@ mod sta {
         test_first(
             instructions!(sta test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -1511,7 +1520,7 @@ mod stx {
         test_first(
             instructions!(stx test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1520,7 +1529,7 @@ mod stx {
         test_first(
             instructions!(stx test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1529,7 +1538,7 @@ mod stx {
         test_first(
             instructions!(stx test,y),
             OP,
-            AddressMode::AbsoluteY(AddressReference::new("test")),
+            AddressMode::AbsoluteY(AddressReference::new(&"test")),
         );
     }
 }
@@ -1549,7 +1558,7 @@ mod sty {
         test_first(
             instructions!(sty test),
             OP,
-            AddressMode::Absolute(AddressReference::new("test")),
+            AddressMode::Absolute(AddressReference::new(&"test")),
         );
     }
 
@@ -1558,7 +1567,7 @@ mod sty {
         test_first(
             instructions!(sty test+1),
             OP,
-            AddressMode::Absolute(AddressReference::with_offset("test", 1)),
+            AddressMode::Absolute(AddressReference::with_offset(&"test", 1)),
         );
     }
 
@@ -1567,7 +1576,7 @@ mod sty {
         test_first(
             instructions!(sty test,x),
             OP,
-            AddressMode::AbsoluteX(AddressReference::new("test")),
+            AddressMode::AbsoluteX(AddressReference::new(&"test")),
         );
     }
 }


### PR DESCRIPTION
Implements the macros to support indirect addressing modes

- indirect `jmp (my_label)`
- indexed indirect `lda (label, x)`
- indirect indexed `lda (label), y)`
